### PR TITLE
Disable HTTPS checking

### DIFF
--- a/auth/src/app.ts
+++ b/auth/src/app.ts
@@ -14,7 +14,7 @@ app.use(express.json());
 app.use(
   cookieSession({
     signed: false,
-    secure: process.env.NODE_ENV !== 'test',
+    secure: false,
   })
 );
 

--- a/orders/src/app.ts
+++ b/orders/src/app.ts
@@ -13,7 +13,7 @@ app.use(express.json());
 app.use(
   cookieSession({
     signed: false,
-    secure: process.env.NODE_ENV !== 'test',
+    secure: false,
   })
 );
 app.use(currentUser);

--- a/payments/src/app.ts
+++ b/payments/src/app.ts
@@ -10,7 +10,7 @@ app.use(express.json());
 app.use(
   cookieSession({
     signed: false,
-    secure: process.env.NODE_ENV !== 'test',
+    secure: false,
   })
 );
 app.use(currentUser);

--- a/tickets/src/app.ts
+++ b/tickets/src/app.ts
@@ -13,7 +13,7 @@ app.use(express.json());
 app.use(
   cookieSession({
     signed: false,
-    secure: process.env.NODE_ENV !== 'test',
+    secure: false,
   })
 );
 app.use(currentUser);


### PR DESCRIPTION
Services are configured to only use cookies when the user is on an HTTPS connection. This will cause auth to fail during the initial deploy of our app, since HTTPS is not setup right now.